### PR TITLE
Disable HTTP persistent connections (keep-alive)

### DIFF
--- a/plugp100/core/http_client.py
+++ b/plugp100/core/http_client.py
@@ -8,6 +8,7 @@ class AsyncHttp:
 
     def __init__(self, session: aiohttp.ClientSession):
         self.session = session
+        self.session.connector._force_close = True
 
     async def async_make_post(self, url, json: Any) -> aiohttp.ClientResponse:
         async with self.session.post(url, json=json) as response:


### PR DESCRIPTION
`ServerDisconnectedError` exception is raised occasionally while using the library. I was able to find this bug because https://github.com/petretiandrea/home-assistant-tapo-p100/issues/12 condition occurred to me too.

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "<stdin>", line 5, in main
  File "/usr/local/lib/python3.8/site-packages/plugp100/api.py", line 73, in get_state
    return TapoDeviceState(await self._get_state())
  File "/usr/local/lib/python3.8/site-packages/plugp100/api.py", line 204, in _get_state
    response = await self.http.async_make_post_cookie(f"{self.url}?token={self.token}", request_body,
  File "/usr/local/lib/python3.8/site-packages/plugp100/core/http_client.py", line 18, in async_make_post_cookie
    async with self.session.post(url, json=json, cookies=cookie) as response:
  File "/usr/local/lib/python3.8/site-packages/aiohttp/client.py", line 1117, in __aenter__
    self._resp = await self._coro
  File "/usr/local/lib/python3.8/site-packages/aiohttp/client.py", line 544, in _request
    await resp.start(conn)
  File "/usr/local/lib/python3.8/site-packages/aiohttp/client_reqrep.py", line 890, in start
    message, payload = await self._protocol.read()  # type: ignore
  File "/usr/local/lib/python3.8/site-packages/aiohttp/streams.py", line 604, in read
    await self._waiter
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected
```

HTTP server implementation in Tapo products is very partial and does not seem to implement HTTP keep-alive. After one HTTP response, the Tapo product will try to terminate the connection (See packet #<span></span>22).

Our modern library may send the next request before processing the termination (See packet #<span></span>23). Sending data to the terminated connection causes `ServerDisconnectedError` exception.

```
    1   0.000000 192.168.101.217 → 192.168.101.216 TCP 78 49450 → 80 [SYN] Seq=0 Win=64240 Len=0 MSS=1460 SACK_PERM=1 TSval=3004273768 TSecr=0 WS=128
    2   0.002416 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49450 [SYN, ACK] Seq=0 Ack=1 Win=2920 Len=0 MSS=1250
    3   0.002429 192.168.101.217 → 192.168.101.216 TCP 58 49450 → 80 [ACK] Seq=1 Ack=1 Win=64240 Len=0
    4   0.002730 192.168.101.217 → 192.168.101.216 TCP 239 POST /app HTTP/1.1  [TCP segment of a reassembled PDU]
    5   0.002833 192.168.101.217 → 192.168.101.216 HTTP/JSON 384 POST /app HTTP/1.1 , JavaScript Object Notation (application/json)
    6   0.005889 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49450 [ACK] Seq=1 Ack=508 Win=2413 Len=0
    7   0.197836 192.168.101.216 → 192.168.101.217 TCP 235 HTTP/1.1 200 OK  [TCP segment of a reassembled PDU]
    8   0.197857 192.168.101.217 → 192.168.101.216 TCP 58 49450 → 80 [ACK] Seq=508 Ack=178 Win=64063 Len=0
    9   0.200256 192.168.101.216 → 192.168.101.217 HTTP/JSON 266 HTTP/1.1 200 OK , JavaScript Object Notation (application/json)
   10   0.200460 192.168.101.217 → 192.168.101.216 TCP 58 49450 → 80 [FIN, ACK] Seq=508 Ack=387 Win=64063 Len=0
   11   0.203092 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49450 [ACK] Seq=387 Ack=509 Win=2412 Len=0
   12   0.226692 192.168.101.217 → 192.168.101.216 TCP 78 49452 → 80 [SYN] Seq=0 Win=64240 Len=0 MSS=1460 SACK_PERM=1 TSval=3004273995 TSecr=0 WS=128
   13   0.229284 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49452 [SYN, ACK] Seq=0 Ack=1 Win=2920 Len=0 MSS=1250
   14   0.229297 192.168.101.217 → 192.168.101.216 TCP 58 49452 → 80 [ACK] Seq=1 Ack=1 Win=64240 Len=0
   15   0.229551 192.168.101.217 → 192.168.101.216 TCP 294 POST /app HTTP/1.1  [TCP segment of a reassembled PDU]
   16   0.229618 192.168.101.217 → 192.168.101.216 HTTP/JSON 396 POST /app HTTP/1.1 , JavaScript Object Notation (application/json)
   17   0.232689 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49452 [ACK] Seq=1 Ack=575 Win=2346 Len=0
   18   0.487252 192.168.101.216 → 192.168.101.217 TCP 144 HTTP/1.1 200 OK  [TCP segment of a reassembled PDU]
   19   0.487284 192.168.101.217 → 192.168.101.216 TCP 58 49452 → 80 [ACK] Seq=575 Ack=87 Win=64154 Len=0
   20   0.490486 192.168.101.216 → 192.168.101.217 HTTP/JSON 207 HTTP/1.1 200 OK , JavaScript Object Notation (application/json)
   21   0.490511 192.168.101.217 → 192.168.101.216 TCP 58 49452 → 80 [ACK] Seq=575 Ack=236 Win=64005 Len=0
   22   0.491361 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49452 [FIN, ACK] Seq=236 Ack=575 Win=2346 Len=0
   23   0.492767 192.168.101.217 → 192.168.101.216 TCP 333 POST /app?token=<secret>HTTP/1.1  [TCP segment of a reassembled PDU]
   24   0.492849 192.168.101.217 → 192.168.101.216 HTTP/JSON 180 POST /app?token=<secret> HTTP/1.1 , JavaScript Object Notation (application/json)
   25   0.492996 192.168.101.217 → 192.168.101.216 TCP 58 49452 → 80 [FIN, ACK] Seq=972 Ack=237 Win=64005 Len=0
   26   0.495723 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49452 [RST, ACK] Seq=237 Ack=850 Win=2920 Len=0
   27   0.497050 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49452 [RST, ACK] Seq=237 Ack=972 Win=2920 Len=0
   28   0.498268 192.168.101.216 → 192.168.101.217 TCP 64 80 → 49452 [RST, ACK] Seq=237 Ack=973 Win=2920 Len=0
```

I think there are environments where this problem never occurs, and others where it always occurs. The time needed in connection termination phase can vary depending on the environment, so I believe that simply adding `asyncio.sleep` is not a good way to go.

This PR forces opening a new connection for every request/response pair (i.e., disable keep-alive connections) by highjacking [`force_close` parameter](https://docs.aiohttp.org/en/stable/client_reference.html#connectors).