### PR TITLE
Clear invalid cookies to fix login failure

### DIFF
--- a/plugp100/core/http_client.py
+++ b/plugp100/core/http_client.py
@@ -15,6 +15,7 @@ class AsyncHttp:
             return await self._force_read_release(response)
 
     async def async_make_post_cookie(self, url, json, cookie) -> aiohttp.ClientResponse:
+        self.session.cookie_jar.clear()
         async with self.session.post(url, json=json, cookies=cookie) as response:
             return await self._force_read_release(response)
 


### PR DESCRIPTION
My P110, at least, seems to send an invalid Set-Cookie: header of the form `Set-Cookie: TP_SESSIONID=...;TIMEOUT=1440'`. aiohttp seems to parse this as an extra cookie, stores it in the cookie jar, and sends it back - which causes the API endpoint to simply return a dummy HTML "OK" page. Fix seems to be to clear the cookie jar (we manually specify the cookie anyway.)