### PR TITLE
fix(l530): ensure brightness is sent when setting color or temperature

### DIFF
--- a/plugp100/api/tapo_api_client.py
+++ b/plugp100/api/tapo_api_client.py
@@ -55,10 +55,10 @@ class TapoApiClient(TapoApi):
         return await self.__set_device_state(LightParams(brightness=brightness))
 
     async def set_color_temperature(self, color_temperature: int) -> bool:
-        return await self.__set_device_state(LightParams(color_temperature=color_temperature, hue=0, saturation=0))
+        return await self.__set_device_state(LightParams(color_temperature=color_temperature, hue=0, saturation=0, brightness=(await self.get_state()).state["brightness"]))
 
     async def set_hue_saturation(self, hue: int, saturation: int) -> bool:
-        return await self.__set_device_state(LightParams(hue=hue, saturation=saturation, color_temperature=0))
+        return await self.__set_device_state(LightParams(hue=hue, saturation=saturation, color_temperature=0, brightness=(await self.get_state()).state["brightness"]))
 
     async def set_light_effect(self, effect: LightEffectData) -> bool:
         try:


### PR DESCRIPTION
Related to issue #80.

When using L530 firmware version `1.0.9 Build 220526 Rel.203202`, hardware version `2.0`, switch and brightness are ok, but changing color or temperature has no effect.

During investigations, it appears that these version needs to have the brightness given along the new color or temperature. We need to obtain the current brightness and send it again in the same request.

We recover the current brightness with `(await self.get_state()).state["brightness"]` and give it in the `LightParams` for the `set_color_temperature` and `set_hue_saturation` functions.

Tested under python 3.11, and HomeAssistant 2023.1.7 with python 3.10 with the previous bulb and two older : firmware `1.2.2 Build 20220110 Rel. 72329`, harware_version `1.0.0`.

I created this PR, but I don't really know how this module is built (neither do I know how other Tapo bulbs works -> maybe some of them doesn't have brightness concept ?), so feel free to provide any suggestions or correction.