### PR TITLE
feat: Make more deviceinfo response fields accessible

### DIFF
--- a/plugp100/responses/device_state.py
+++ b/plugp100/responses/device_state.py
@@ -1,6 +1,6 @@
 import base64
 from dataclasses import dataclass
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 import semantic_version
 
@@ -16,6 +16,14 @@ class DeviceState:
 class PlugDeviceState(DeviceState):
     info: "DeviceInfo"
     device_on: bool
+    on_time: int
+
+    power_protection_status: str
+    default_states: Dict
+
+    auto_off: bool
+    auto_off_time_remaining: int
+
 
     @staticmethod
     def try_from_json(kwargs: dict[str, Any]) -> Either["PlugDeviceState", Exception]:
@@ -24,8 +32,12 @@ class PlugDeviceState(DeviceState):
                 PlugDeviceState(
                     info=DeviceInfo(**kwargs),
                     device_on=kwargs.get("device_on", False),
-                )
-            )
+                power_protection_status=kwargs.get("power_protection_status"),
+                on_time=kwargs.get("on_time"),
+                auto_off=kwargs.get("auto_off_status") == "on",
+                auto_off_time_remaining=kwargs.get("auto_off_remain_time"),
+                default_states=kwargs.get("default_states")
+            ))
         except Exception as e:
             return Left(e)
 
@@ -114,18 +126,7 @@ class DeviceInfo:
     time_difference: int
     language: str
 
-    # device state
-    power_protection_status: str
-    device_on: bool
-    on_time: int
-
-    # autooff
-    auto_off: bool
-    auto_off_time_remaining: int
-
     is_hardware_v2: bool = property(lambda self: self.hardware_version == "2.0")
-
-
 
     def __init__(self, **kwargs):
         self.device_id = kwargs["device_id"]
@@ -138,7 +139,6 @@ class DeviceInfo:
         self.model = kwargs["model"]
         self.type = kwargs["type"]
         self.overheated = kwargs.get("overheated", False)
-        self.power_protection_status = kwargs["power_protection_status"]
         self.ip = kwargs['ip']
         self.ssid = base64.b64decode(kwargs["ssid"]).decode()
         self.signal_level = kwargs.get("signal_level", 0)
@@ -150,15 +150,6 @@ class DeviceInfo:
         self.timezone = kwargs["region"]
         self.time_difference = kwargs["time_diff"]
         self.language = kwargs["lang"]
-
-        # device state
-        self.device_on = kwargs["device_on"]
-        self.on_time = kwargs["on_time"]
-
-        # auto off
-        self.auto_off = (kwargs["auto_off_status"] == "on")
-        self.auto_off_time_remaining = kwargs["auto_off_remain_time"]
-
 
     def get_semantic_firmware_version(self) -> semantic_version.Version:
         pieces = self.firmware_version.split("Build")

--- a/plugp100/responses/device_state.py
+++ b/plugp100/responses/device_state.py
@@ -24,7 +24,6 @@ class PlugDeviceState(DeviceState):
     auto_off: bool
     auto_off_time_remaining: int
 
-
     @staticmethod
     def try_from_json(kwargs: dict[str, Any]) -> Either["PlugDeviceState", Exception]:
         try:
@@ -32,12 +31,13 @@ class PlugDeviceState(DeviceState):
                 PlugDeviceState(
                     info=DeviceInfo(**kwargs),
                     device_on=kwargs.get("device_on", False),
-                power_protection_status=kwargs.get("power_protection_status"),
-                on_time=kwargs.get("on_time"),
-                auto_off=kwargs.get("auto_off_status") == "on",
-                auto_off_time_remaining=kwargs.get("auto_off_remain_time"),
-                default_states=kwargs.get("default_states")
-            ))
+                    power_protection_status=kwargs.get("power_protection_status"),
+                    on_time=kwargs.get("on_time"),
+                    auto_off=kwargs.get("auto_off_status") == "on",
+                    auto_off_time_remaining=kwargs.get("auto_off_remain_time"),
+                    default_states=kwargs.get("default_states"),
+                )
+            )
         except Exception as e:
             return Left(e)
 
@@ -117,7 +117,7 @@ class DeviceInfo:
     signal_level: int
     rssi: int
     friendly_name: str
-    
+
     # location data
     latitude: int
     longitude: int
@@ -129,8 +129,8 @@ class DeviceInfo:
 
     def __init__(self, **kwargs):
         self.device_id = kwargs["device_id"]
-        self.hardware_id = kwargs['hw_id']
-        self.oem_id = kwargs['oem_id']
+        self.hardware_id = kwargs["hw_id"]
+        self.oem_id = kwargs["oem_id"]
         self.firmware_version = kwargs["fw_ver"]
         self.hardware_version = kwargs["hw_ver"]
         self.mac = kwargs["mac"]
@@ -138,7 +138,7 @@ class DeviceInfo:
         self.model = kwargs["model"]
         self.type = kwargs["type"]
         self.overheated = kwargs.get("overheated", False)
-        self.ip = kwargs['ip']
+        self.ip = kwargs["ip"]
         self.ssid = base64.b64decode(kwargs["ssid"]).decode()
         self.signal_level = kwargs.get("signal_level", 0)
         self.rssi = kwargs.get("rssi", 0)

--- a/plugp100/responses/device_state.py
+++ b/plugp100/responses/device_state.py
@@ -103,7 +103,6 @@ class DeviceInfo:
     device_id: str
     hardware_id: str
     oem_id: str
-    timezone: str
     firmware_version: str
     hardware_version: str
     ip: str

--- a/plugp100/responses/device_state.py
+++ b/plugp100/responses/device_state.py
@@ -89,20 +89,48 @@ class LedStripDeviceState(DeviceState):
 @dataclass
 class DeviceInfo:
     device_id: str
+    hardware_id: str
+    oem_id: str
+    timezone: str
     firmware_version: str
     hardware_version: str
+    ip: str
     mac: str
     nickname: str
     model: str
     type: str
     overheated: bool
+
+    # wifi
+    ssid: str
     signal_level: int
     rssi: int
     friendly_name: str
+    
+    # location data
+    latitude: int
+    longitude: int
+    timezone: str
+    time_difference: int
+    language: str
+
+    # device state
+    power_protection_status: str
+    device_on: bool
+    on_time: int
+
+    # autooff
+    auto_off: bool
+    auto_off_time_remaining: int
+
     is_hardware_v2: bool = property(lambda self: self.hardware_version == "2.0")
+
+
 
     def __init__(self, **kwargs):
         self.device_id = kwargs["device_id"]
+        self.hardware_id = kwargs['hw_id']
+        self.oem_id = kwargs['oem_id']
         self.firmware_version = kwargs["fw_ver"]
         self.hardware_version = kwargs["hw_ver"]
         self.mac = kwargs["mac"]
@@ -110,9 +138,27 @@ class DeviceInfo:
         self.model = kwargs["model"]
         self.type = kwargs["type"]
         self.overheated = kwargs.get("overheated", False)
+        self.power_protection_status = kwargs["power_protection_status"]
+        self.ip = kwargs['ip']
+        self.ssid = base64.b64decode(kwargs["ssid"]).decode()
         self.signal_level = kwargs.get("signal_level", 0)
         self.rssi = kwargs.get("rssi", 0)
         self.friendly_name = self.model if self.nickname == "" else self.nickname
+
+        self.latitude = kwargs["latitude"]
+        self.longitude = kwargs["longitude"]
+        self.timezone = kwargs["region"]
+        self.time_difference = kwargs["time_diff"]
+        self.language = kwargs["lang"]
+
+        # device state
+        self.device_on = kwargs["device_on"]
+        self.on_time = kwargs["on_time"]
+
+        # auto off
+        self.auto_off = (kwargs["auto_off_status"] == "on")
+        self.auto_off_time_remaining = kwargs["auto_off_remain_time"]
+
 
     def get_semantic_firmware_version(self) -> semantic_version.Version:
         pieces = self.firmware_version.split("Build")


### PR DESCRIPTION
This will make most of the available payload data for P110 available through `PlugDeviceState` and `DeviceInfo`.