### PR TITLE
feat: Add get_device_time to base device

### DIFF
--- a/plugp100/api/base_tapo_device.py
+++ b/plugp100/api/base_tapo_device.py
@@ -39,8 +39,11 @@ class _BaseTapoDevice:
         )
 
     async def get_device_time(self) -> Either[TimeInfo, Exception]:
-        return (await self._api.execute_raw_request(TapoRequest(method="get_device_time", params=None))) | \
-                TimeInfo.try_from_json
+        return (
+            await self._api.execute_raw_request(
+                TapoRequest(method="get_device_time", params=None)
+            )
+        ) | TimeInfo.try_from_json
 
     async def get_state_as_json(self) -> Either[Json, Exception]:
         return await self._api.get_device_info()

--- a/plugp100/api/base_tapo_device.py
+++ b/plugp100/api/base_tapo_device.py
@@ -3,6 +3,7 @@ from plugp100.common.functional.either import Either
 from plugp100.common.utils.json_utils import Json
 from plugp100.requests.tapo_request import TapoRequest
 from plugp100.responses.device_usage_info import DeviceUsageInfo
+from plugp100.responses.time_info import TimeInfo
 
 
 class _BaseTapoDevice:
@@ -36,6 +37,10 @@ class _BaseTapoDevice:
         return await self._api.execute_raw_request(
             TapoRequest(method=method, params=params)
         )
+
+    async def get_device_time(self) -> Either[TimeInfo, Exception]:
+        return (await self._api.execute_raw_request(TapoRequest(method="get_device_time", params=None))) | \
+                TimeInfo.try_from_json
 
     async def get_state_as_json(self) -> Either[Json, Exception]:
         return await self._api.get_device_info()

--- a/plugp100/responses/time_info.py
+++ b/plugp100/responses/time_info.py
@@ -12,7 +12,7 @@ class TimeInfo:
     region: str
 
     def local_time(self) -> datetime:
-        """Return datetime object using the given"""
+        """Return datetime object using the device-given timezone information."""
         # import zoneinfo here for python <3.9 compatibility
         from zoneinfo import ZoneInfo
 

--- a/plugp100/responses/time_info.py
+++ b/plugp100/responses/time_info.py
@@ -1,0 +1,27 @@
+import dataclasses
+from typing import Any
+from datetime import datetime
+import pytz
+
+from plugp100.common.functional.either import Right, Either, Left
+
+@dataclasses.dataclass
+class TimeInfo:
+    time_diff: int
+    timestamp: int
+    region: str
+
+    def local_time(self) -> datetime:
+        """Return datetime object using the given """
+        return datetime.fromtimestamp(self.timestamp, tz=pytz.timezone(self.region))
+
+    @staticmethod
+    def try_from_json(kwargs: dict[str, Any]) -> Either['TimeInfo', Exception]:
+        try:
+            return Right(TimeInfo(
+                time_diff=kwargs.get('time_diff'),
+                timestamp=kwargs.get('timestamp'),
+                region=kwargs.get('region')
+            ))
+        except Exception as e:
+            return Left(e)

--- a/plugp100/responses/time_info.py
+++ b/plugp100/responses/time_info.py
@@ -1,9 +1,9 @@
 import dataclasses
 from typing import Any
 from datetime import datetime
-import pytz
 
 from plugp100.common.functional.either import Right, Either, Left
+
 
 @dataclasses.dataclass
 class TimeInfo:
@@ -12,16 +12,21 @@ class TimeInfo:
     region: str
 
     def local_time(self) -> datetime:
-        """Return datetime object using the given """
-        return datetime.fromtimestamp(self.timestamp, tz=pytz.timezone(self.region))
+        """Return datetime object using the given"""
+        # import zoneinfo here for python <3.9 compatibility
+        from zoneinfo import ZoneInfo
+
+        return datetime.fromtimestamp(self.timestamp, tz=ZoneInfo(self.region))
 
     @staticmethod
-    def try_from_json(kwargs: dict[str, Any]) -> Either['TimeInfo', Exception]:
+    def try_from_json(kwargs: dict[str, Any]) -> Either["TimeInfo", Exception]:
         try:
-            return Right(TimeInfo(
-                time_diff=kwargs.get('time_diff'),
-                timestamp=kwargs.get('timestamp'),
-                region=kwargs.get('region')
-            ))
+            return Right(
+                TimeInfo(
+                    time_diff=kwargs.get("time_diff"),
+                    timestamp=kwargs.get("timestamp"),
+                    region=kwargs.get("region"),
+                )
+            )
         except Exception as e:
             return Left(e)


### PR DESCRIPTION
Adds support for querying device time. `local_time` can be used to return tz-aware datetime given pytz is installed. This could be left for downstreams to handle (to avoid pytz dependency, perhaps preferred?), or alternatively ported to use `zoneinfo` (supported only by python 3.9+ though...).

Let me know what you think!