### PR TITLE
Tapo discovery protocol improvements and Windows support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiohttp>=3.8.1
 semantic-version==2.10.0
 cryptography>=38.0.3
 scapy>=2.5.0
+psutil==5.9.6


### PR DESCRIPTION
As discussed at https://github.com/petretiandrea/plugp100/pull/138 and https://github.com/petretiandrea/home-assistant-tapo-p100/issues/83.

I fixed the Windows related issues:

- using select.select instead of select.poll (which is not available on Windows apparently)
- sending out the discovery magic on all network interfaces (again, Windows didn't select the right LAN interface by default, but it is probably more robust this way anyway)
