### PR TITLE
handle different possibilities for state of is_open

### DIFF
--- a/plugp100/new/components/smart_door_component.py
+++ b/plugp100/new/components/smart_door_component.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Any
 
 from plugp100.new.components.device_component import DeviceComponent
 
+
+_LOGGER = logging.getLogger("SmartDoorComponent")
 
 # TODO: get component_negotiation for Tapo Smart Door sensor
 # this class is actually too specific for SmartDoor, the component can be called open_closed
@@ -12,4 +15,9 @@ class SmartDoorComponent(DeviceComponent):
         self.is_open = False
 
     async def update(self, current_state: dict[str, Any] | None = None):
-        self.is_open = current_state["is_open"]
+        if "is_open" in current_state:
+            self.is_open = current_state["is_open"]
+        elif "open" in current_state:
+            self.is_open = current_state["open"]
+        else:
+            _LOGGER.warning("Open state not found in current state")


### PR DESCRIPTION
My T110 is returning the status as 'open'.

{'parent_device_id': '<deleted>', 'hw_ver': '1.0', 'fw_ver': '1.9.0 Build 230704 Rel.154531', 'device_id': '<deleted>', 'mac': '<deleted>', 'type': 'SMART.TAPOSENSOR', 'model': 'T110', 'hw_id': '<deleted>', 'oem_id': '<deleted>', 'specs': 'EU', 'category': 'subg.trigger.contact-sensor', 'bind_count': 1, 'status_follow_edge': False, 'status': 'online', 'lastOnboardingTimestamp': 1716207870, 'rssi': -54, 'signal_level': 3, 'jamming_rssi': -115, 'jamming_signal_level': 1, 'at_low_battery': False, 'open': True, 'nickname': '<deleted>', 'avatar': 'sensor_t110', 'report_interval': 16, 'region': '<deleted>'}

This update enables handling both the possibilities of 'open' and 'is_open'.