### PR TITLE
Restore Hub functionality

### DIFF
--- a/plugp100/new/device_factory.py
+++ b/plugp100/new/device_factory.py
@@ -110,6 +110,8 @@ def _get_device_class_from_model_type(device_type: str) -> Type[TapoDevice]:
         return TapoBulb
     elif device_type == "SMART.TAPOHUB":
         return TapoHub
+    elif device_type == "SMART.KASAHUB":
+        return TapoHub
     elif device_type == "SMART.IPCAMERA":
         raise Exception(f"Device of type {device_type} not supported!")
     return TapoDevice


### PR DESCRIPTION
Since the breaking changes in version > 4.0.3 it wasn't possible to add the children/sub devices of a hub (https://github.com/petretiandrea/home-assistant-tapo-p100/issues/773)

Debugging this issue showed that the device wasn't classified as hub as the API returns it as KASAHUB instead of the expected TAPOHUB. Considering it's possible that either one are used I added the KASAHUB option.

Using the debugger I changed the value on the fly and everything worked out great, all sub devices were recognized perfectly fine.

![image](https://github.com/user-attachments/assets/7aec28d3-5f6c-4d30-b5d2-f3071825f32f)
![image](https://github.com/user-attachments/assets/80a4af66-8153-4d39-8316-0ee9cfd89d4c)
