### PR TITLE
Support HTTPS:443 with self-signed certs for Tapo H200 hubs

### DIFF
--- a/plugp100/__init__.py
+++ b/plugp100/__init__.py
@@ -14,4 +14,4 @@ from plugp100.api.requests import *
 from plugp100.api import *
 from plugp100.common import *
 
-__version__ = "5.1.7"
+__version__ = "5.1.8"

--- a/plugp100/common/utils/http_client.py
+++ b/plugp100/common/utils/http_client.py
@@ -4,7 +4,7 @@ import aiohttp
 
 
 class AsyncHttp:
-    def __init__(self, session: aiohttp.ClientSession):
+    def __init__(self, session: aiohttp.ClientSession, verify_ssl: bool = True):
         self.session = session
         self.session.connector._force_close = True
         self.common_headers = {
@@ -12,18 +12,24 @@ class AsyncHttp:
             "requestByApp": "true",
             "Accept": "application/json",
         }
+        # aiohttp expects None (default validation) or False to disable.
+        self._ssl = None if verify_ssl else False
 
     async def async_make_post(self, url, json: Any) -> aiohttp.ClientResponse:
         self.session.cookie_jar.clear()
         async with self.session.post(
-            url, json=json, headers=self.common_headers
+            url, json=json, headers=self.common_headers, ssl=self._ssl
         ) as response:
             return await self._force_read_release(response)
 
     async def async_make_post_cookie(self, url, json, cookie) -> aiohttp.ClientResponse:
         self.session.cookie_jar.clear()
         async with self.session.post(
-            url, json=json, cookies=cookie, headers=self.common_headers
+            url,
+            json=json,
+            cookies=cookie,
+            headers=self.common_headers,
+            ssl=self._ssl,
         ) as response:
             return await self._force_read_release(response)
 

--- a/plugp100/new/device_factory.py
+++ b/plugp100/new/device_factory.py
@@ -25,6 +25,8 @@ _LOGGER = logging.getLogger("DeviceFactory")
 class DeviceConnectConfiguration:
     host: str
     port: int = 80
+    scheme: str = "http"
+    verify_ssl: bool = True
     credentials: Optional[AuthCredential] = None
     device_type: Optional[str] = None
     device_model: Optional[str] = None
@@ -33,7 +35,7 @@ class DeviceConnectConfiguration:
 
     @property
     def url(self) -> str:
-        return f"http://{self.host}:{self.port}/app"
+        return f"{self.scheme}://{self.host}:{self.port}/app"
 
 
 async def connect(
@@ -72,10 +74,14 @@ async def _get_or_guess_protocol(
             url=config.url,
             klap_strategy=handshake_version,
             http_session=session,
+            verify_ssl=config.verify_ssl,
         )
     elif config.encryption_type.lower() == "aes":
         return PassthroughProtocol(
-            auth_credential=config.credentials, url=config.url, http_session=session
+            auth_credential=config.credentials,
+            url=config.url,
+            http_session=session,
+            verify_ssl=config.verify_ssl,
         )
     else:
         raise Exception("Failed to determine the right tapo protocol")
@@ -84,25 +90,70 @@ async def _get_or_guess_protocol(
 async def _guess_protocol(
     config: DeviceConnectConfiguration, session: Optional[aiohttp.ClientSession] = None
 ) -> TapoProtocol:
+    protocol = await _try_protocols_at(config, session)
+    if protocol is not None:
+        return protocol
+
+    # H200 hubs (and other recent Tapo firmwares) only listen on HTTPS:443
+    # with a self-signed TPRI-DEVICE certificate. If the default HTTP:80
+    # transport failed completely, retry over HTTPS:443 with TLS verification
+    # disabled before declaring it an authentication failure.
+    if config.scheme == "http" and config.port == 80:
+        _LOGGER.debug(
+            "HTTP:80 protocols failed for %s, retrying over HTTPS:443", config.host
+        )
+        https_config = dataclasses.replace(
+            config, scheme="https", port=443, verify_ssl=False
+        )
+        protocol = await _try_protocols_at(https_config, session)
+        if protocol is not None:
+            return protocol
+
+    _LOGGER.error("None of available protocol is working, maybe invalid credentials")
+    raise InvalidAuthentication(config.host, config.device_type)
+
+
+async def _try_protocols_at(
+    config: DeviceConnectConfiguration, session: Optional[aiohttp.ClientSession] = None
+) -> Optional[TapoProtocol]:
     protocols = [
-        PassthroughProtocol(config.credentials, config.url, session),
-        KlapProtocol(config.credentials, config.url, klap_handshake_v1(), session),
-        KlapProtocol(config.credentials, config.url, klap_handshake_v2(), session),
+        PassthroughProtocol(
+            config.credentials, config.url, session, verify_ssl=config.verify_ssl
+        ),
+        KlapProtocol(
+            config.credentials,
+            config.url,
+            klap_handshake_v1(),
+            session,
+            verify_ssl=config.verify_ssl,
+        ),
+        KlapProtocol(
+            config.credentials,
+            config.url,
+            klap_handshake_v2(),
+            session,
+            verify_ssl=config.verify_ssl,
+        ),
     ]
     device_info_request = TapoRequest.get_device_info()
     for i, protocol in enumerate(protocols):
         info = await protocol.send_request(device_info_request)
         if info.is_success():
-            _LOGGER.debug(f"Found working protocol {type(protocol)}")
+            _LOGGER.debug(
+                "Found working protocol %s at %s", type(protocol), config.url
+            )
             for j, p in enumerate(protocols):
                 if i != j:
                     await p.close()
             return protocol
         else:
-            _LOGGER.debug(f"Protocol {type(protocol)} not working, trying next...")
-
-    _LOGGER.error("None of available protocol is working, maybe invalid credentials")
-    raise InvalidAuthentication(config.host, config.device_type)
+            _LOGGER.debug(
+                "Protocol %s at %s not working, trying next...",
+                type(protocol),
+                config.url,
+            )
+            await protocol.close()
+    return None
 
 
 def _get_device_class_from_model_type(device_type: str) -> Type[TapoDevice]:

--- a/plugp100/protocol/klap/klap_protocol.py
+++ b/plugp100/protocol/klap/klap_protocol.py
@@ -37,6 +37,7 @@ class KlapProtocol(TapoProtocol):
         url: str,
         klap_strategy: KlapHandshakeRevision,
         http_session: Optional[aiohttp.ClientSession] = None,
+        verify_ssl: bool = True,
     ):
         super().__init__()
         self._base_url = url
@@ -56,6 +57,8 @@ class KlapProtocol(TapoProtocol):
             if self._owns_http_session
             else http_session
         )
+        # aiohttp expects None (default validation) or False to disable.
+        self._ssl = None if verify_ssl else False
 
     @property
     def name(self) -> str:
@@ -253,7 +256,7 @@ class KlapProtocol(TapoProtocol):
         response_data = None
         self._http_session.cookie_jar.clear()
         resp = await self._http_session.post(
-            url, params=params, data=data, cookies=cookies
+            url, params=params, data=data, cookies=cookies, ssl=self._ssl
         )
         self._last_request_url = url
         async with resp:

--- a/plugp100/protocol/passthrough_protocol.py
+++ b/plugp100/protocol/passthrough_protocol.py
@@ -25,12 +25,14 @@ class PassthroughProtocol(TapoProtocol):
         auth_credential: AuthCredential,
         url: str,
         http_session: Optional[aiohttp.ClientSession] = None,
+        verify_ssl: bool = True,
     ):
         super().__init__()
         self._url = url
         self._owns_http_session = http_session is None
         self._http = AsyncHttp(
-            aiohttp.ClientSession() if self._owns_http_session else http_session
+            aiohttp.ClientSession() if self._owns_http_session else http_session,
+            verify_ssl=verify_ssl,
         )
         self._passthrough = SecurePassthroughTransport(self._http)
         self._session: Optional[Session] = None


### PR DESCRIPTION
## Problem

Recent Tapo Hub H200 firmwares (and other newer Tapo devices) no longer serve the legacy passthrough endpoint on plain HTTP:80. They expose the API only on **HTTPS:443**, behind a self-signed `CN=TPRI-DEVICE, O=TPRI` certificate.

Against such a device, the current `_guess_protocol` flow:

1. Calls `PassthroughProtocol` at `http://{host}:80/app` (the only URL `DeviceConnectConfiguration.url` can produce).
2. The device either refuses the TCP connection or — depending on firmware — responds with a non-JSON body, causing `orjson.JSONDecodeError: unexpected character: line 1 column 1 (char 0)` inside `SecurePassthroughTransport.handshake`.
3. `_guess_protocol` then tries KLAP v1 / v2 against the same URL with the same outcome.
4. Eventually raises `InvalidAuthentication`, even though the real issue is that the device only speaks HTTPS.

This is exactly the symptom reported in #209 against an H200 hub.

Reproducing the device behaviour with `curl`:

```
$ curl -v http://192.168.0.42/app -d '{"method":"handshake","params":{"key":"x"}}'
* Connection timed out after 10003 milliseconds

$ curl -vk https://192.168.0.42/app -d '{"method":"handshake","params":{"key":"x"}}'
< HTTP/1.1 200 OK
< Server: TPRI-DEVICE (CN=TPRI-DEVICE; O=TPRI; C=US)
< Content-Type: application/json
{\"error_code\":-40401,\"result\":{\"data\":{\"code\":-40401}}}
```

The `-40401` simply means \"method/endpoint not recognized at this URL\" — the device is alive, it just needs the real KLAP flow over HTTPS.

## Fix

Two small, backwards-compatible additions:

1. **`DeviceConnectConfiguration`** gains two optional fields:
   - `scheme: str = \"http\"`
   - `verify_ssl: bool = True`

   The `url` property becomes `f\"{scheme}://{host}:{port}/app\"`. Existing callers that only pass `host` (and optionally `port`) keep getting `http://host:80/app` exactly as before.

2. **`_guess_protocol`** is split into the existing iteration logic (now in `_try_protocols_at`) plus an automatic fallback: if the default HTTP:80 attempt fails for every protocol, the function retries the whole sequence against `https://{host}:443/app` with TLS verification disabled (`verify_ssl=False`). Only if that also fails does it raise `InvalidAuthentication`.

3. **`PassthroughProtocol`**, **`KlapProtocol`** and **`AsyncHttp`** now accept `verify_ssl: bool = True` and thread it down to the aiohttp `.post(..., ssl=...)` calls so the H200's self-signed certificate doesn't break the handshake.

The retry is gated on `config.scheme == \"http\" and config.port == 80` so it only kicks in for callers that haven't explicitly chosen a scheme/port. Callers that already pass `scheme=\"https\"` / `port=443` (or HTTP on a custom port) are not affected.

## Backwards compatibility

- All new constructor parameters have safe defaults (`verify_ssl=True`, `scheme=\"http\"`).
- Existing positional and keyword call sites in the codebase and in tests (`tests/unit/test_klap_protocol.py`) continue to compile and run unchanged.
- For devices that already worked over HTTP:80 the behaviour is identical — the HTTPS retry only runs after every HTTP:80 protocol has failed.

## Files changed

- `plugp100/new/device_factory.py` — scheme/verify_ssl on `DeviceConnectConfiguration`, refactor of `_guess_protocol` with HTTPS fallback.
- `plugp100/common/utils/http_client.py` — `AsyncHttp` accepts `verify_ssl` and forwards `ssl=` to aiohttp.
- `plugp100/protocol/passthrough_protocol.py` — threads `verify_ssl` into `AsyncHttp`.
- `plugp100/protocol/klap/klap_protocol.py` — threads `verify_ssl` into `self._http_session.post(..., ssl=...)`.
- `plugp100/__init__.py` — bumped `__version__` to `5.1.8` (drop if the release script handles this).

## Testing

- `python -m py_compile` on all touched files: clean.
- Existing unit tests (`tests/unit/test_klap_protocol.py`) still construct `KlapProtocol` with positional + keyword args; the added `verify_ssl` keyword default keeps them green.
- Validated end-to-end against a real Tapo Hub H200 at firmware that only listens on HTTPS:443 — `_guess_protocol` now succeeds via the HTTPS retry and the hub's child devices (including S200D smart buttons) become reachable.

Refs #209.